### PR TITLE
Update mem_verify.sh

### DIFF
--- a/mem_verify.sh
+++ b/mem_verify.sh
@@ -111,7 +111,7 @@ ANONCHK
 	declare anonHugePagesEnabled=0
 
 	if [[ $anonHugePagesConfigured -gt 0 ]]; then
-		grep '[always]' $anonFileToChk >/dev/null && {
+		grep '\[always\]' $anonFileToChk >/dev/null && {
 			#echo anonymous HugePages are enabled
 			anonHugePagesEnabled=1
 		}


### PR DESCRIPTION
Fixed ANONCHK regex to correctly grep the whole string and not the single letters in 'always'.